### PR TITLE
Ensure line range is reported the right way around, fixes #132

### DIFF
--- a/src/Coverage.php
+++ b/src/Coverage.php
@@ -118,7 +118,7 @@ namespace Pest\PluginCoverage;
       * Generates an array of missing coverage on the following format:.
       *
       * ```
-      * ['11', '20..25', '50', '60...80'];
+      * ['11', '20..25', '50', '60..80'];
       * ```
       *
       * @param File $file
@@ -147,8 +147,11 @@ namespace Pest\PluginCoverage;
 
              if (array_key_exists($lastKey, $array) && strpos($array[$lastKey], '..') !== false) {
                  [$from]          = explode('..', $array[$lastKey]);
-                 $array[$lastKey] = sprintf('%s..%s', $from, $line);
-
+                 if ($line > $from) {
+                     $array[$lastKey] = sprintf('%s..%s', $from, $line);
+                 } else {
+                     $array[$lastKey] = sprintf('%s..%s', $line, $from);
+                 }
                  return $array;
              }
 


### PR DESCRIPTION
This isn't an especially elegant fix, but it should do the job, and it fixes it in my usage where I spotted this issue. Ultimately it would be better to figure out why the numbers are arriving in the wrong order, though I guess it's really not that important!

Also fixed a comment typo.